### PR TITLE
upgraded to dotnet 5 as required by dotnet interactive

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,7 +1,7 @@
-name: dotnet3.1
+name: dotnet5.0
 channels:
   - conda-forge
   - defaults
 dependencies:
-  - dotnet=3.1
+  - dotnet=5.0
   


### PR DESCRIPTION
Looks like dotnet interactive upgraded and new installations now require the .NET 5 SDK. I've upgraded the dependency in your .yml file to account for this. 

I've tested that it works from my fork [here](https://mybinder.org/v2/gh/RobotOptimist/AdventOfCode2020CSharp/HEAD?filepath=Day01.ipynb)

Thank you again for figuring this out on Binder!